### PR TITLE
Add Visual Studio Code to IDE options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Articles
 * [Sublime Text essential plugins and resources](https://github.com/dreikanter/sublime-bookmarks)
 * [vim-awesome](http://vimawesome.com/)
 * Bram Moolenaar (Vim author), [Seven habits of effective text editing](http://www.moolenaar.net/habits.html) ([presentation](http://www.moolenaar.net/habits_2007.pdf)).
+* [VScode](https://code.visualstudio.com/). "Visual Studio Code Can Do That?" - [Smashing Magazine, Jan 2018](https://www.smashingmagazine.com/2018/01/visual-studio-code/)
 
 ### Engineering management
 


### PR DESCRIPTION
In 2019, VScode has muscled its way to the forefront of editors. Personally having observed and tested various flows (expert level VIM + shell commands, well-configured Emacs, and paid-for IDEs such as Webstorm), I argue that VScode is simply one of the best editing experiences available today. As such, it should be included in such a repo. 