### PR TITLE
Fixed database acronym

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Biases don't only apply to hiring. For instance, the fundamental attribution bia
 * [A plain english introduction to CAP Theorem](http://ksat.me/a-plain-english-introduction-to-cap-theorem/)
 * [NOSQL Patterns](http://horicky.blogspot.nl/2009/11/nosql-patterns.html)
 * [NoSQL Databases: a Survey and Decision Guidance](https://medium.baqend.com/nosql-databases-a-survey-and-decision-guidance-ea7823a822d#.9fe79qr90)
-* [Safe Operations For High Volume PostgreSQL](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (this is for PostgreSQL but works great for other db as well).
+* [Safe Operations For High Volume PostgreSQL](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) (this is for PostgreSQL but works great for other DBs as well).
 * [Zero downtime database migrations](https://blog.rainforestqa.com/2014-06-27-zero-downtime-database-migrations/) (code examples are using Rails but this works great for any programming language)
 * [SQL styleguide](http://www.sqlstyle.guide/)
 * [Algorithms Behind Modern Storage Systems](https://queue.acm.org/detail.cfm?id=3220266), ACM Queue


### PR DESCRIPTION
The READEME.md file contains the following line:

> this is for PostgreSQL but works great for other db as well

I changed the capitalization and made the acronym for databases "DBs" since the word "other" implies that the proceeding word should be plural.