### PR TITLE
Add Engineering Manager Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
     - [Internet](#internet)
     - [Interviewing](#interviewing)
 - [AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice for engineering managers and software engineers
+- [Blog for Engineering Managers](https://blog4ems.com) - Practical guidance, templates, and resources for engineering managers
     - [Kubernetes](#kubernetes)
     - [Large Language Model (LLM)](#large-language-model-llm)
     - [Learning & memorizing](#learning--memorizing)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
       - [Postmortem](#postmortem)
     - [Internet](#internet)
     - [Interviewing](#interviewing)
+- [AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice for engineering managers and software engineers
     - [Kubernetes](#kubernetes)
     - [Large Language Model (LLM)](#large-language-model-llm)
     - [Learning & memorizing](#learning--memorizing)


### PR DESCRIPTION
## Add Engineering Manager Resources

### AI Interview Coach
[AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice built for software engineers and engineering managers. 130+ role-specific questions, STAR-format scoring across 6 dimensions, probing follow-ups, and 3 interviewer personas (Startup CTO, Big Tech VP, Scale-up Director). Free first question.

### Blog for Engineering Managers
[Blog for Engineering Managers](https://blog4ems.com) - Practical guidance, templates, and resources for engineering managers. Weekly newsletter covering hiring, talent management, team execution, and leadership development. 50+ Notion templates and an Engineering Manager's Field Guide.