### PR TITLE
Add Techpresso newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2364,6 +2364,7 @@ Newsletters:
 - [PyCoders](https://pycoders.com/) (Python)
 - [Posthog](https://newsletter.posthog.com/)
 - [Tech Talks Weekly](https://techtalksweekly.io/)
+- [Techpresso](https://dupple.com/techpresso) (AI & tech)
 
 Blogs:
 


### PR DESCRIPTION
Adds [Techpresso](https://dupple.com/techpresso) to the Newsletters section under Keeping up-to-date.

Techpresso is a free daily AI & tech newsletter read by 200,000+ subscribers.