### PR TITLE
Add TutorialSearch to Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ There are some free books available, including:
 - [jwasham/coding-interview-university](https://github.com/jwasham/coding-interview-university): a complete computer science study plan to become a software engineer.
 - [Teach Yourself Computer Science](https://teachyourselfcs.com/): an opinionated set of the best CS resources.
 - [ossu/computer-science](https://github.com/ossu/computer-science): free self-taught education in Computer Science!
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/programming-languages/c-professional) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Topics
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ There are some free books available, including:
 - [jwasham/coding-interview-university](https://github.com/jwasham/coding-interview-university): a complete computer science study plan to become a software engineer.
 - [Teach Yourself Computer Science](https://teachyourselfcs.com/): an opinionated set of the best CS resources.
 - [ossu/computer-science](https://github.com/ossu/computer-science): free self-taught education in Computer Science!
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Topics
 


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Courses* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/programming-languages/c-professional) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/programming-languages/c-professional) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.